### PR TITLE
allow reuse of conn buffers across connections

### DIFF
--- a/redhub.go
+++ b/redhub.go
@@ -141,6 +141,17 @@ type connBuffer struct {
 	lastAccess time.Time
 }
 
+func newConnBuffer() *connBuffer {
+	return &connBuffer{
+		buf:        bytes.Buffer{},
+		command:    []resp.Command{},
+		mu:         &sync.Mutex{},
+		pb:         pool.NewBytePool(),
+		ip:         pool.NewIntPool(),
+		lastAccess: time.Now(),
+	}
+}
+
 func (cb *connBuffer) reset() {
 	cb.buf = bytes.Buffer{}
 	cb.mu = &sync.Mutex{}


### PR DESCRIPTION
Re-use conn buffers across connections to help with short lived connections allocating buffers.